### PR TITLE
Use default GOPATH, when env variable is empty

### DIFF
--- a/common.go
+++ b/common.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"fmt"
+	"go/build"
 	"io"
 	"log"
 	"math/rand"
@@ -63,11 +64,10 @@ func (p *Params) generateBinaryName() string {
 
 func generateBinaryPrefix() string {
 	path := os.Getenv("GOPATH")
-	if path != "" {
-		return fmt.Sprintf("%s/bin/%s", path, binaryName)
+	if path == "" {
+		path = build.Default.GOPATH
 	}
-
-	return path
+	return fmt.Sprintf("%s/bin/%s", path, binaryName)
 }
 
 // runCommand runs the command with given name and arguments. It copies the

--- a/common_test.go
+++ b/common_test.go
@@ -8,7 +8,7 @@ func TestParamsGet(t *testing.T) {
 
 	run := params.Get("run")
 	if run != "statler" {
-		t.Error("Expected statler but got %s in params.Get()", run)
+		t.Errorf("Expected statler but got %s in params.Get()", run)
 		t.FailNow()
 	}
 }
@@ -20,7 +20,7 @@ func TestParamsClone(t *testing.T) {
 	params.cloneRunFlag()
 	watch := params.Get("watch")
 	if watch != "statler" {
-		t.Error("Expected statler but got %s when watch param is not set", watch)
+		t.Errorf("Expected statler but got %s when watch param is not set", watch)
 	}
 
 	params.Watcher["watch"] = "waldorf"

--- a/watch.go
+++ b/watch.go
@@ -41,7 +41,7 @@ func MustRegisterWatcher(params *Params) *Watcher {
 	if watchVendorStr != "" {
 		watchVendor, err = strconv.ParseBool(watchVendorStr)
 		if err != nil {
-			log.Println("Wrong watch-vendor value: %s (default=false)", watchVendorStr)
+			log.Printf("Wrong watch-vendor value: %s (default=false)\n", watchVendorStr)
 		}
 	}
 


### PR DESCRIPTION
When the GOPATH is empty  (which is optional since go 1.8) the [watcher panics](#22)

I've patched watcher.generateBinaryPrefix() to use:

```go
gopath := os.Getenv("GOPATH")
if gopath == "" {
    gopath = build.Default.GOPATH
}
```
I also fixed some linter issues, so `go test` passes again.