### PR TITLE
Add watch-ignore command

### DIFF
--- a/common.go
+++ b/common.go
@@ -14,7 +14,7 @@ import (
 // Binary name used for built package
 const binaryName = "watcher"
 
-var watcherFlags = []string{"run", "watch", "watch-vendor"}
+var watcherFlags = []string{"run", "watch", "watch-vendor", "watch-ignore"}
 
 // Params is used for keeping go-watcher and application flag parameters
 type Params struct {


### PR DESCRIPTION
Added -watch-ignore argument so projects using other vendor-like folders such as a node_modules or vendor can use watcher. Paths are relative from the active directory and separated by semi-colon.
`watcher -watch-ignore "node_modules;js/vendor"`